### PR TITLE
feat: render math markup on the server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,13 @@
   "name": "dead-guru/devichan",
   "description": "devichan imageboard",
   "type": "project",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/dead-guru/latex2mathml-php.git",
+      "no-api": true
+    }
+  ],
   "require": {
     "php": ">=8.1",
     "ext-mbstring": ">=8.1",
@@ -19,7 +26,8 @@
     "mrclay/jsmin-php": "^2.4",
     "matthiasmullie/minify": "^1.3",
     "ezyang/htmlpurifier": "^4.16",
-    "bepsvpt/blurhash": "^2.1"
+    "bepsvpt/blurhash": "^2.1",
+    "dead-guru/latex2mathml-php": "^1.5.1"
   },
   "autoload": {
     "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcb9b2b0d926a6c6b8845329cdc95bd1",
+    "content-hash": "befce1ef59c27134fd1d1ae6688d7a1c",
     "packages": [
         {
             "name": "bepsvpt/blurhash",
@@ -127,6 +127,53 @@
             },
             "abandoned": true,
             "time": "2020-05-30T10:05:48+00:00"
+        },
+        {
+            "name": "dead-guru/latex2mathml-php",
+            "version": "v1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dead-guru/latex2mathml-php.git",
+                "reference": "0749731467b5b6a788a4d9190ac7ab60f620449a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dead-guru/latex2mathml-php/zipball/0749731467b5b6a788a4d9190ac7ab60f620449a",
+                "reference": "0749731467b5b6a788a4d9190ac7ab60f620449a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5 || ^11.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Latex2MathML\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "snorky22",
+                    "email": "chaplains.francois@orange.fr"
+                }
+            ],
+            "description": "Pure PHP library for LaTeX to MathML and OMML conversion",
+            "keywords": [
+                "converter",
+                "latex",
+                "mathml",
+                "omml",
+                "php",
+                "word"
+            ],
+            "time": "2026-08-26T16:17:20+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2192,7 +2239,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -2205,6 +2252,6 @@
         "ext-gettext": "*",
         "ext-imagick": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/inc/MathRenderer.php
+++ b/inc/MathRenderer.php
@@ -1,0 +1,99 @@
+<?php
+
+final class MathRenderer
+{
+	private const MAX_SOURCE_LENGTH = 10000;
+	private const MATHML_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
+	private const SAFE_ELEMENTS = [
+		'math', 'menclose', 'merror', 'mfenced', 'mfrac', 'mi', 'mmultiscripts',
+		'mn', 'mo', 'mover', 'mpadded', 'mphantom', 'mprescripts', 'mroot',
+		'mrow', 'ms', 'mspace', 'msqrt', 'mstyle', 'msub', 'msubsup', 'msup',
+		'mtable', 'mtd', 'mtext', 'mtr', 'munder', 'munderover', 'none',
+	];
+	private const SAFE_ATTRIBUTES = [
+		'accent', 'accentunder', 'align', 'columnalign', 'columnlines',
+		'columnspacing', 'columnspan', 'depth', 'display', 'displaystyle', 'fence',
+		'form', 'height', 'largeop', 'linethickness', 'lspace', 'mathvariant',
+		'maxsize', 'minsize', 'movablelimits', 'rowalign', 'rowlines', 'rowspan',
+		'rowspacing', 'rspace', 'scriptlevel', 'stretchy', 'symmetric', 'voffset',
+		'width',
+	];
+	private const LENGTH_ATTRIBUTES = [
+		'columnspacing', 'depth', 'height', 'linethickness', 'lspace', 'maxsize',
+		'minsize', 'rowspacing', 'rspace', 'voffset', 'width',
+	];
+
+	public static function render(string $escapedLatex): string
+	{
+		$escapedLatex = trim($escapedLatex);
+		if ($escapedLatex === '' || strlen($escapedLatex) > self::MAX_SOURCE_LENGTH) {
+			return self::renderSource($escapedLatex);
+		}
+
+		try {
+			$mathml = Latex2MathML\Converter::convert($escapedLatex, 'block');
+			return '<span class="math-rendered">' . self::sanitize($mathml) . '</span>';
+		} catch (Throwable $exception) {
+			return self::renderSource($escapedLatex);
+		}
+	}
+
+	private static function sanitize(string $mathml): string
+	{
+		$document = new DOMDocument('1.0', 'UTF-8');
+		$previousErrorMode = libxml_use_internal_errors(true);
+
+		try {
+			if (!$document->loadXML($mathml, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
+				throw new RuntimeException('Invalid MathML output.');
+			}
+		} finally {
+			libxml_clear_errors();
+			libxml_use_internal_errors($previousErrorMode);
+		}
+
+		$root = $document->documentElement;
+		if (!$root || $root->localName !== 'math' || $root->namespaceURI !== self::MATHML_NAMESPACE) {
+			throw new RuntimeException('Invalid MathML root element.');
+		}
+
+		foreach ($document->getElementsByTagName('*') as $element) {
+			if (!in_array($element->localName, self::SAFE_ELEMENTS, true)) {
+				throw new RuntimeException('Unsafe MathML element.');
+			}
+
+			$attributes = [];
+			foreach ($element->attributes as $attribute) {
+				$attributes[] = $attribute;
+			}
+
+			foreach ($attributes as $attribute) {
+				if ($attribute->namespaceURI === 'http://www.w3.org/2000/xmlns/') {
+					continue;
+				}
+
+				$name = $attribute->localName;
+				if (!in_array($name, self::SAFE_ATTRIBUTES, true) || !self::isSafeValue($name, $attribute->value)) {
+					$element->removeAttributeNode($attribute);
+				}
+			}
+		}
+
+		return $document->saveXML($root);
+	}
+
+	private static function isSafeValue(string $name, string $value): bool
+	{
+		if (!in_array($name, self::LENGTH_ATTRIBUTES, true)) {
+			return true;
+		}
+
+		$length = '[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:em|ex|px|pt|pc|in|cm|mm|%|mu)?';
+		return preg_match('/^(?:' . $length . ')(?:\s+' . $length . ')*$/', $value) === 1;
+	}
+
+	private static function renderSource(string $escapedLatex): string
+	{
+		return '<code class="math-source">[math]' . $escapedLatex . '[/math]</code>';
+	}
+}

--- a/inc/config.php
+++ b/inc/config.php
@@ -673,6 +673,7 @@
 	$config['markup'][] = array("/~~(.+?)~~/", "<s>\$1</s>"); //u
 	$config['markup'][] = array("/\*\*(.+?)\*\*/", "<span class=\"spoiler\">\$1</span>"); //spoiler
 	$config['markup'][] = array("/^[ |\t]*==(.+?)==[ |\t]*$/m", "<span class=\"heading\">\$1</span>"); //heading
+	$config['markup_math'] = "/\[math\](.*?)\[\/math\]/is";
 
 	// Code markup. This should be set to a regular expression, using tags you want to use. Examples:
 	// "/\[code\](.*?)\[\/code\]/is"

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2020,6 +2020,16 @@ function markup(&$body, $track_cites = false, $op = false) {
 		}, $body);
 	}
 
+	$math_markup = array();
+	if ($config['markup_math']) {
+		$math_token = bin2hex(random_bytes(8));
+		$body = preg_replace_callback($config['markup_math'], function($matches) use (&$math_markup, $math_token) {
+			$placeholder = "%%DEVICHAN_MATH_{$math_token}_" . count($math_markup) . "%%";
+			$math_markup[$placeholder] = MathRenderer::render($matches[1]);
+			return $placeholder;
+		}, $body);
+	}
+
 	foreach ($config['markup'] as $markup) {
 		if (is_string($markup[1])) {
 			$body = preg_replace($markup[0], $markup[1], $body);
@@ -2250,6 +2260,10 @@ function markup(&$body, $track_cites = false, $op = false) {
 
 	// replace tabs with 8 spaces
 	$body = str_replace("\t", '		', $body);
+
+	foreach ($math_markup as $placeholder => $mathml) {
+		$body = str_replace($placeholder, $mathml, $body);
+	}
 
 	return $tracked_cites;
 }

--- a/js/comment-toolbar.js
+++ b/js/comment-toolbar.js
@@ -67,6 +67,15 @@ if (active_page === 'thread' || active_page === 'index') {
 				prefix: '```',
 				suffix: '```'
 			},
+			math: {
+				text: _('Math'),
+				short: '∑',
+				key: 'm',
+				multiline: true,
+				exclusiveline: false,
+				prefix: '[math]',
+				suffix: '[/math]'
+			},
 			heading: {
 				text: _('Heading'),
 				short: _('H'),
@@ -270,7 +279,15 @@ if (active_page === 'thread' || active_page === 'index') {
 		};
 
 		// setup default rules for customizing
-		if (!localStorage.formatText_rules_1) localStorage.formatText_rules_1 = JSON.stringify(self.rules);
+		if (!localStorage.formatText_rules_1) {
+			localStorage.formatText_rules_1 = JSON.stringify(self.rules);
+		} else {
+			var savedRules = JSON.parse(localStorage.formatText_rules_1);
+			if (!savedRules.math) {
+				savedRules.math = self.rules.math;
+				localStorage.formatText_rules_1 = JSON.stringify(savedRules);
+			}
+		}
 
 		// setup code to be ran when page is ready (work around for main.js compilation).
 		$(document).ready(function(){

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -309,6 +309,19 @@ div.post div.body {
     white-space: pre-wrap
 }
 
+span.math-rendered {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: .25em 0;
+    white-space: normal
+}
+
+span.math-rendered math {
+    font-size: 1.15em
+}
+
 div.post.reply {
     background: #d6daf0;
     margin: .2em 4px;


### PR DESCRIPTION
## What changed

- Add `[math]...[/math]` markup and render it as native MathML on the server.
- Use a PHP 8.1-compatible fork of `latex2mathml-php`.
- Sanitize generated MathML with an element and attribute allowlist.
- Keep math inside code blocks unchanged and show invalid input as source.
- Add a Math button to the existing comment toolbar.
- Add horizontal overflow styling for long formulas.

No browser-side math renderer is added.

## Verification

- PHP syntax checks pass.
- Composer validation passes.
- JavaScript syntax check passes.
- Targeted markup tests cover fractions, powers, the supplied long formula, code blocks, invalid input, and unsafe markup.
- Local post flow renders native MathML in the browser with six fractions and no script nodes.
- Production PHP 8.1 autoload smoke renders `\\frac{1}{2}` as MathML.
