### PR TITLE
fix(mod): return to post after deleting file

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1145,13 +1145,14 @@ function deleteFile($id, $remove_entirely_if_already=true, $file=null) {
 	$query->execute() or error(db_error($query));
 	if (!$post = $query->fetch(PDO::FETCH_ASSOC))
 		error($config['error']['invalidpost']);
+	$thread = $post['thread'] ?: $id;
 	$files = json_decode($post['files']);
 	$file_to_delete = $file !== false ? $files[(int)$file] : (object)array('file' => false);
 
 	if (!$files[0]) error(_('That post has no files.'));
 
 	if ($files[0]->file == 'deleted' && $post['num_files'] == 1 && !$post['thread'])
-		return; // Can't delete OP's image completely.
+		return $thread; // Can't delete OP's image completely.
 
 	$query = prepare(sprintf("UPDATE ``posts_%s`` SET `files` = :file WHERE `id` = :id", $board['uri']));
 	if (($file && $file_to_delete->file == 'deleted') && $remove_entirely_if_already) {
@@ -1178,10 +1179,9 @@ function deleteFile($id, $remove_entirely_if_already=true, $file=null) {
 	$query->bindValue(':id', $id, PDO::PARAM_INT);
 	$query->execute() or error(db_error($query));
 
-	if ($post['thread'])
-		buildThread($post['thread']);
-	else
-		buildThread($id);
+	buildThread($thread);
+
+	return $thread;
 }
 
 // rebuild post (markup)

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1695,7 +1695,7 @@ function mod_deletefile($board, $post, $file) {
 		error($config['error']['noaccess']);
 	
 	// Delete file
-	deleteFile($post, TRUE, $file);
+	$thread = deleteFile($post, TRUE, $file);
 	// Record the action
 	modLog("Deleted file from post #{$post}");
 	
@@ -1705,7 +1705,7 @@ function mod_deletefile($board, $post, $file) {
 	rebuildThemes('post-delete', $board);
 	
 	// Redirect
-	header('Location: ?/' . sprintf($config['board_path'], $board) . $config['file_index'], true, $config['redirect_http']);
+	header('Location: ?/' . sprintf($config['board_path'], $board) . $config['dir']['res'] . sprintf($config['file_page'], $thread) . '#' . $post, true, $config['redirect_http']);
 }
 
 function mod_spoiler_image($board, $post, $file) {

--- a/tests/Http/ModeratorBoardAndPostCest.php
+++ b/tests/Http/ModeratorBoardAndPostCest.php
@@ -120,38 +120,58 @@ final class ModeratorBoardAndPostCest
     public function administratorCanSpoilerAndDeleteAnUploadedFile(HttpTester $I): void
     {
         $this->loginAsAdmin($I);
-        $body = 'E2E file moderation thread';
+        $threadBody = 'E2E file moderation thread';
 
         $I->amOnPage('/mod.php?/b/');
+        $postButton = $I->grabAttributeFrom(
+            'form[name="post"] input[name="post"]',
+            'value',
+        );
+        $I->submitForm('form[name="post"]', [
+            'board' => 'b',
+            'body' => $threadBody,
+            'password' => 'e2e-file-thread',
+            'embed' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            'post' => $postButton,
+        ]);
+        $this->assertHealthyPage($I);
+        $threadId = (int) $I->grabFromDatabase('posts_b', 'id', [
+            'body_nomarkup' => $threadBody,
+        ]);
+        $I->assertGreaterThan(2, $threadId);
+
+        $replyBody = 'E2E file moderation reply';
+        $I->amOnPage('/mod.php?/b/res/' . $threadId . '.html');
         $I->attachFile(
             'form[name="post"] input[name="file"]',
             '../../../static/banners/default.png',
         );
-        $I->fillField('form[name="post"] textarea[name="body"]', $body);
-        $I->fillField('form[name="post"] input[name="password"]', 'e2e-file');
+        $I->fillField('form[name="post"] textarea[name="body"]', $replyBody);
+        $I->fillField('form[name="post"] input[name="password"]', 'e2e-file-reply');
         $I->click('form[name="post"] input[name="post"]');
         $this->assertHealthyPage($I);
-        $threadId = (int) $I->grabFromDatabase('posts_b', 'id', [
-            'body_nomarkup' => $body,
+        $replyId = (int) $I->grabFromDatabase('posts_b', 'id', [
+            'body_nomarkup' => $replyBody,
         ]);
-        $I->assertGreaterThan(2, $threadId);
+        $I->assertGreaterThan($threadId, $replyId);
 
         $I->amOnPage('/mod.php?/b/res/' . $threadId . '.html');
         $spoilerUrl = $this->grabConfirmedAction(
             $I,
-            "b/spoiler/{$threadId}/0",
+            "b/spoiler/{$replyId}/0",
         );
         $I->amOnPage($spoilerUrl);
-        $files = (string) $I->grabFromDatabase('posts_b', 'files', ['id' => $threadId]);
+        $files = (string) $I->grabFromDatabase('posts_b', 'files', ['id' => $replyId]);
         $I->assertStringContainsString('"thumb":"spoiler"', $files);
 
         $I->amOnPage('/mod.php?/b/res/' . $threadId . '.html');
         $deleteFileUrl = $this->grabConfirmedAction(
             $I,
-            "b/deletefile/{$threadId}/0",
+            "b/deletefile/{$replyId}/0",
         );
         $I->amOnPage($deleteFileUrl);
-        $files = (string) $I->grabFromDatabase('posts_b', 'files', ['id' => $threadId]);
+        $I->seeCurrentUrlEquals('/mod.php?/b/res/' . $threadId . '.html#' . $replyId);
+        $files = (string) $I->grabFromDatabase('posts_b', 'files', ['id' => $replyId]);
         $I->assertStringContainsString('"file":"deleted"', $files);
 
         $I->amOnPage('/mod.php?/b/res/' . $threadId . '.html');


### PR DESCRIPTION
## Summary

- Return moderators to the parent thread after file deletion.
- Add an anchor for the post that contained the file.
- Reuse the thread ID from the existing database query.
- Cover file deletion from a reply with an HTTP E2E test.

## Tests

- Targeted Codeception HTTP test: 1 test, 21 assertions.
- Targeted PHPUnit integration test: 1 test, 4 assertions.
- PHP syntax checks for both changed product files.
